### PR TITLE
Updated passenger_ruby regex for latest configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     dest=/etc/nginx/nginx.conf
     state=present
     backup=yes
-    regexp='#?\s*passenger_ruby /usr/bin/ruby;'
+    regexp='#?\s*passenger_ruby /usr/bin/passenger_free_ruby;'
     line='passenger_ruby /usr/bin/ruby;'
 
 - name: Restart nginx


### PR DESCRIPTION
Build fails with old regex as it outputs `passenger_ruby /usr/bin/ruby;` to the bottom of nginx.conf file.
